### PR TITLE
docs: fix example for multi words stories names

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ After that your story with id `example-button--primary` will be rendered on prev
 * To convert old url queries `selectedKind` and `selectedStory` (users of storybook@5) to story id you can use the following helper:
 
 ```js
-import { toId } from '@storybook/csf';
-const storyId = toId(selectedKind, selectedStory);
+import { toId, storyNameFromExport } from '@storybook/csf';
+const storyId = toId(selectedKind, storyNameFromExport(selectedStory));
 ```


### PR DESCRIPTION
I faced a problem with multi-word story name. I have the following story:

```typescript
export default {
  title: 'components/MyComponent',
  component: MyComponent,
} as Meta<IMyComponentProps<{}>>;

export const Basic = () => <MyComponent>Some content.</MyComponent>;
export const WithUnlinkAction = () => <MyComponent onUnlink={onUnlink}>Some content.</MyComponent>;
```

And the story iframe path is `/iframe.html?id=components-mycomponent--with-unlink-action`. The following code will cause the wrong result:

```typescript
import { toId } from '@storybook/csf';
const storyId = toId('components/MyComponent', 'WithUnlinkAction');
```

It returns `components-mycomponent--withunlinkaction`, so the story name has no hyphens, but it should have for open iframe correctly. According to Storybook sources, more accurately it’s module [StoryStoreFacade.ts](https://github.com/storybookjs/storybook/blob/v6.4.9/lib/client-api/src/StoryStoreFacade.ts#L193), which is responsible for building stories cache, they use also `storyNameFromExport` method to add hyphens between ‘words’ in story name.

So the proper code for getting story’s id is:

```typescript
import { toId, storyNameFromExport } from '@storybook/csf';
const storyId = toId(selectedKind, storyNameFromExport(selectedStory));
```