### PR TITLE
fix: reset story args when selecting the same story

### DIFF
--- a/src/addon/decorators/hermione.test.ts
+++ b/src/addon/decorators/hermione.test.ts
@@ -124,10 +124,11 @@ describe("hermione-addon/hermione-decorator", () => {
             });
         });
 
-        test("should reset story which is already rendered", async () => {
+        test("should reset story and its args if story is already rendered", async () => {
             P.delay(10)
                 .then(() => channel.emit(Events.STORY_RENDERED))
                 .then(() => P.delay(10).then(() => channel.emit(Events.STORY_MISSING)))
+                .then(() => P.delay(10).then(() => channel.emit(Events.STORY_ARGS_UPDATED)))
                 .then(() => P.delay(10).then(() => channel.emit(Events.STORY_RENDERED)));
 
             await hermioneDecorator.selectStory("story-id");
@@ -135,6 +136,9 @@ describe("hermione-addon/hermione-decorator", () => {
 
             expect(channel.once).toHaveBeenCalledWith(Events.STORY_MISSING, expect.any(Function));
             expect(channel.emit).toHaveBeenCalledWith(Events.SET_CURRENT_STORY, { storyId: NON_EXISTENT_STORY_ID });
+
+            expect(channel.once).toHaveBeenCalledWith(Events.STORY_ARGS_UPDATED, expect.any(Function));
+            expect(channel.emit).toHaveBeenCalledWith(Events.RESET_STORY_ARGS, { storyId: "story-id" });
         });
 
         test("should update story args", async () => {

--- a/src/addon/decorators/hermione.ts
+++ b/src/addon/decorators/hermione.ts
@@ -44,6 +44,7 @@ export default class HermioneDecorator {
         try {
             if (this.currentStoryId === storyId) {
                 await this.resetStory();
+                await this.resetStoryArgs(storyId);
             } else {
                 this.currentStoryId = storyId;
             }
@@ -73,6 +74,13 @@ export default class HermioneDecorator {
         return new Promise(resolve => {
             this.channel.once(Events.STORY_MISSING, resolve);
             this.channel.emit(Events.SET_CURRENT_STORY, { storyId: NON_EXISTENT_STORY_ID });
+        });
+    }
+
+    private resetStoryArgs(storyId: string): Promise<void> {
+        return new Promise(resolve => {
+            this.channel.once(Events.STORY_ARGS_UPDATED, resolve);
+            this.channel.emit(Events.RESET_STORY_ARGS, { storyId });
         });
     }
 


### PR DESCRIPTION
## Описание

#### Ситуация

Допустим, что имеется история `S` в `Storybook`.
У нее есть три аргумента: `a`, `b` и `c`.
Предположим, что с использованием этой истории есть два теста:

* `t1`, в котором задействуются все три аргумента

* `t2`, в котором задействуются только `b` и `c`

Порядок выполнения тестов неизвестен и не будет.

#### Проблема

Если `t1` исполнится раньше, то `t2` достанется оставшийся от `t1` аргумент `a`, который в данном случае совсем не нужен и может привести к некорректному виду на `ui` (положим, что `a` суть заголовок, видимый пользователю).
Если повезет, и `t2` исполнится до `t1`, то проблемы не будет.
Это создает неявную зависимость тестов друг от друга и делает их нестабильными.

#### Предлагаемое решение

Расширить метод [selectStory](https://github.com/gemini-testing/hermione-storybook/blob/master/src/addon/decorators/hermione.ts#L41), принудительно сбрасывая аргументы выбираемой истории через отправку в [канал](https://github.com/gemini-testing/hermione-storybook/blob/master/src/addon/decorators/hermione.ts#L26) события [RESET_STORY_ARGS](https://github.com/storybookjs/storybook/blob/2dc0cbec02614ddc6ef1da3e8a29d39cd3770544/code/lib/preview-web/src/Preview.tsx#L97), обработка которого приведет к желаемому [сбросу](https://github.com/storybookjs/storybook/blob/2dc0cbec02614ddc6ef1da3e8a29d39cd3770544/code/lib/preview-web/src/Preview.tsx#L264) аргументов истории.

Так мы сможем гарантировать, что история воспользуется **только лишь** теми аргументами, что были явно ей переданы.

```typescript
// A helper function
private resetStoryArgs(storyId: string): Promise<void> {
  	return new Promise(resolve => {
  		this.channel.once(Events.STORY_ARGS_UPDATED, resolve);
		this.channel.emit(Events.RESET_STORY_ARGS, { storyId });
	});
}
```

Все описание и решение предложено by @jasonrammoray